### PR TITLE
Make run-levels explicit for compatibility with newer OSes.

### DIFF
--- a/install-piface-real-time-clock.sh
+++ b/install-piface-real-time-clock.sh
@@ -56,7 +56,7 @@ start_on_boot() {
 # Provides:          pifacertc
 # Required-Start:    udev mountkernfs \$remote_fs raspi-config
 # Required-Stop:
-# Default-Start:     S
+# Default-Start:     S 2 3 4 5
 # Default-Stop:
 # Short-Description: Add the PiFace RTC
 # Description:       Add the PiFace RTC


### PR DESCRIPTION
Without this change the service fails to start on Raspbian Fetch.